### PR TITLE
fix: Separate preview and production deployment environments

### DIFF
--- a/.github/workflows/optimize-and-deploy.yml
+++ b/.github/workflows/optimize-and-deploy.yml
@@ -62,6 +62,38 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./public
         cname: thomas.design
+    
+    - name: Create production deployment status
+      if: github.ref == 'refs/heads/main'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          try {
+            // Create a deployment for production
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              task: 'deploy',
+              auto_merge: false,
+              required_contexts: [],
+              environment: 'github-pages',
+              description: 'Production deployment'
+            });
+            
+            // Create a successful deployment status
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: 'success',
+              environment_url: 'https://thomas.design',
+              description: 'Deployed to production',
+              auto_inactive: false
+            });
+          } catch (error) {
+            console.log('Production deployment status creation failed:', error);
+          }
         
     - name: Create deployment status for PR
       if: github.event_name == 'pull_request'
@@ -77,7 +109,7 @@ jobs:
               task: 'deploy',
               auto_merge: false,
               required_contexts: [],
-              environment: 'github-pages',
+              environment: 'preview',
               description: 'PR Build Validation'
             });
             


### PR DESCRIPTION
- PR deployments now use 'preview' environment instead of 'github-pages'
- Production deployments create proper github-pages status with thomas.design URL
- This fixes deployment tracking confusion between Netlify previews and production
- github-pages environment will only show production deployments (thomas.design)
- Preview environment will show PR builds with Netlify URLs

## Description
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Style update
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other: 

## Testing
- [ ] Tested locally with `npm run dev`
- [ ] Ran `npm run pre-deploy` (no errors)
- [ ] Tested on Netlify preview URL
- [ ] Checked in multiple browsers

## Preview Checklist
Once Netlify deploys, please verify:
- [ ] Site loads without redirect issues
- [ ] No console errors
- [ ] Features work as expected
- [ ] Mobile responsive
- [ ] Dark/light mode works

## Screenshots (if applicable)
<!-- Add screenshots here -->

## Additional Notes
<!-- Any additional context -->

---
⏳ Netlify will comment with a preview URL once the build completes.