### PR TITLE
fix: emergency patch to prevent dev indicator showing on production

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,19 +23,25 @@
   command = "npm run build:prod"
   
   [context.production.environment]
-    HUGO_ENV = "production"
+    NODE_ENV = "production"
+    HEXO_ENV = "production"
 
 # Deploy preview context - runs for PRs
 [context.deploy-preview]
   command = "npm run build:prod"
   
   [context.deploy-preview.environment]
-    # Can add preview-specific env vars here
+    NODE_ENV = "production"
+    HEXO_ENV = "production"
     PREVIEW = "true"
 
 # Branch deploy context
 [context.branch-deploy]
   command = "npm run build:prod"
+  
+  [context.branch-deploy.environment]
+    NODE_ENV = "production"
+    HEXO_ENV = "production"
 
 # Headers for all routes
 [[headers]]

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build": "npm run build:demos && hexo clean && hexo generate",
     "build:full": "npm run build:demos && npm run build",
-    "build:prod": "npm run pre-deploy && npm run build:demos && hexo clean && hexo generate && npm run optimize",
-    "build:prod:strict": "npm run pre-deploy && npm run build:demos && hexo clean && hexo generate && npm run optimize",
+    "build:prod": "NODE_ENV=production npm run pre-deploy && npm run build:demos && hexo clean && NODE_ENV=production hexo generate && npm run optimize",
+    "build:prod:strict": "NODE_ENV=production npm run pre-deploy && npm run build:demos && hexo clean && NODE_ENV=production hexo generate && npm run optimize",
     "pre-deploy": "node build-system/pre-deploy-check.js",
     "pre-deploy:force": "node build-system/pre-deploy-check.js --force",
     "optimize": "npm run optimize:images && npm run minify",

--- a/themes/san-diego/scripts/worktree-indicator.js
+++ b/themes/san-diego/scripts/worktree-indicator.js
@@ -8,7 +8,18 @@
 
 hexo.extend.filter.register('after_render:html', function(str, data) {
   // Only inject in development mode
-  if (process.env.NODE_ENV === 'production') {
+  // Check multiple conditions to ensure we're not in production
+  if (process.env.NODE_ENV === 'production' || 
+      hexo.env.env === 'production' ||
+      process.env.HEXO_ENV === 'production' ||
+      process.env.NETLIFY === 'true' ||
+      process.env.CI === 'true' ||
+      hexo.config.environment === 'production') {
+    return str;
+  }
+  
+  // Additional safety check - if URL is set and not localhost, don't show
+  if (hexo.config.url && !hexo.config.url.includes('localhost')) {
     return str;
   }
 


### PR DESCRIPTION
## Description
- Added multiple environment checks to worktree-indicator.js
- Set NODE_ENV=production in all build:prod scripts
- Added NODE_ENV and HEXO_ENV to Netlify contexts
- Added URL check to prevent indicator on non-localhost domains

This prevents the 'Main • localhost:4000' indicator from appearing on production sites.


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Style update
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other: 

## Testing
- [ ] Tested locally with `npm run dev`
- [ ] Ran `npm run pre-deploy` (no errors)
- [ ] Tested on Netlify preview URL
- [ ] Checked in multiple browsers

## Preview Checklist
Once Netlify deploys, please verify:
- [ ] Site loads without redirect issues
- [ ] No console errors
- [ ] Features work as expected
- [ ] Mobile responsive
- [ ] Dark/light mode works

## Screenshots (if applicable)
<!-- Add screenshots here -->

## Additional Notes
<!-- Any additional context -->

---
⏳ Netlify will comment with a preview URL once the build completes.