### PR TITLE
fix: adjust font sizes in project writeup content

### DIFF
--- a/themes/san-diego/source/styles/_project-tabs.scss
+++ b/themes/san-diego/source/styles/_project-tabs.scss
@@ -259,8 +259,8 @@
 		}
 
 		h3 {
-			// Desktop styles (18px)
-			font-size: var(--font-size-lg);
+			// Desktop styles (xl size)
+			font-size: var(--font-size-xl);
 			font-weight: var(--font-weight-medium);
 			padding: 0;
 			margin: 0;
@@ -278,8 +278,8 @@
 		}
 
 		p {
-			// Updated to 18px for both desktop and all contexts
-			font-size: var(--font-size-lg);
+			// Updated to base size for better readability
+			font-size: var(--font-size-base);
 			margin: 0 0 24px;
 			line-height: var(--line-height-tight).6;
 
@@ -302,7 +302,7 @@
 			li {
 				margin-bottom: 0.5rem;
 				line-height: var(--line-height-tight).6;
-				font-size: var(--font-size-lg); // Match paragraph font size
+				font-size: var(--font-size-base); // Match paragraph font size
 
 				strong {
 					font-weight: var(--font-weight-semibold);


### PR DESCRIPTION
## Description
- Change p elements from font-size-lg to font-size-base
- Change h3 elements from font-size-lg to font-size-xl
- Change list items from font-size-lg to font-size-base

These changes improve readability and hierarchy in project write-ups.
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Style update
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other: 

## Testing
- [x] Tested locally with `npm run dev`
- [x] Ran `npm run pre-deploy` (no errors)
- [ ] Tested on Netlify preview URL
- [ ] Checked in multiple browsers

## Preview Checklist
Once Netlify deploys, please verify:
- [ ] Site loads without redirect issues
- [ ] No console errors
- [ ] Features work as expected
- [ ] Mobile responsive
- [ ] Dark/light mode works

## Screenshots (if applicable)
<!-- Add screenshots here -->

## Additional Notes
<!-- Any additional context -->

---
⏳ Netlify will comment with a preview URL once the build completes.