### PR TITLE
Fix: Resolve gh-pages deployment conflicts

### DIFF
--- a/.github/workflows/optimize-and-deploy.yml
+++ b/.github/workflows/optimize-and-deploy.yml
@@ -65,6 +65,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./public
         cname: thomas.design
+        force_orphan: true
     
     - name: Create production deployment status
       if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
- Fixes the GitHub Pages deployment failure caused by diverged branches
- Adds `force_orphan: true` to ensure clean deployments

## Problem
The deployment was failing with:
```
\! [rejected]        gh-pages -> gh-pages (fetch first)
error: failed to push some refs to 'https://github.com/twalichiewicz/blog.git'
```

## Solution
Using `force_orphan: true` in peaceiris/actions-gh-pages creates a fresh orphan commit for each deployment, preventing conflicts when the gh-pages branch diverges.

## Test plan
- [x] Workflow syntax is valid
- [ ] Merge and verify next deployment succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)