### PR TITLE
fix: update Custom Install link to trigger Works tab programmatically

### DIFF
--- a/source/_posts/custom-install-demo-announcement.md
+++ b/source/_posts/custom-install-demo-announcement.md
@@ -6,4 +6,4 @@ tags:
   - blog
 ---
 
-Took a little while, but I've added inline demoes to the Works page! Started with one of the tricker ones, [Custom Install](https://thomas.design/?tab=portfolio) (look for the (DEMO) sticker).
+Took a little while, but I've added inline demoes to the Works page! Started with one of the tricker ones, <a href="#" onclick="event.preventDefault(); if (window.mobileTabs && typeof window.mobileTabs.switchTab === 'function') { window.mobileTabs.switchTab('portfolio', true); } else { const worksButton = document.querySelector('.tab-button[data-type=portfolio]'); if (worksButton) worksButton.click(); } return false;">Custom Install</a> (look for the (DEMO) sticker).


### PR DESCRIPTION
## Description
- Replace direct navigation link with JavaScript onclick handler
- Supports both mobileTabs.switchTab() and fallback button click
- Prevents page reload and provides smoother user experience

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Style update
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other: 

## Testing
- [ ] Tested locally with `npm run dev`
- [ ] Ran `npm run pre-deploy` (no errors)
- [ ] Tested on Netlify preview URL
- [ ] Checked in multiple browsers

## Preview Checklist
Once Netlify deploys, please verify:
- [ ] Site loads without redirect issues
- [ ] No console errors
- [ ] Features work as expected
- [ ] Mobile responsive
- [ ] Dark/light mode works

## Screenshots (if applicable)
<!-- Add screenshots here -->

## Additional Notes
<!-- Any additional context -->

---
⏳ Netlify will comment with a preview URL once the build completes.