### PR TITLE
fix: add Cloudflare Web Analytics domain to Content Security Policy

### DIFF
--- a/themes/san-diego/layout/_partial/head.ejs
+++ b/themes/san-diego/layout/_partial/head.ejs
@@ -69,6 +69,7 @@
   <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
   <link rel="dns-prefetch" href="https://unpkg.com">
   <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
+  <link rel="dns-prefetch" href="https://static.cloudflareinsights.com">
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="preconnect" href="https://unpkg.com" crossorigin>
   
@@ -115,7 +116,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="X-Frame-Options" content="SAMEORIGIN">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://unpkg.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https:; font-src 'self' https://cdn.jsdelivr.net; connect-src 'self' https:; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://unpkg.com https://cdnjs.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https:; font-src 'self' https://cdn.jsdelivr.net; connect-src 'self' https:; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), interest-cohort=()">
   
   <!-- Robots Meta -->


### PR DESCRIPTION
## Description
- Added https://static.cloudflareinsights.com to script-src CSP directive
- Added DNS prefetch for Cloudflare insights domain for better performance
- Analytics script was already present but being blocked by CSP

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Style update
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other: 

## Testing
- [ ] Tested locally with `npm run dev`
- [ ] Ran `npm run pre-deploy` (no errors)
- [ ] Tested on Netlify preview URL
- [ ] Checked in multiple browsers

## Preview Checklist
Once Netlify deploys, please verify:
- [ ] Site loads without redirect issues
- [ ] No console errors
- [ ] Features work as expected
- [ ] Mobile responsive
- [ ] Dark/light mode works

## Screenshots (if applicable)
<!-- Add screenshots here -->

## Additional Notes
<!-- Any additional context -->

---
⏳ Netlify will comment with a preview URL once the build completes.