### PR TITLE
feat: Add provocative blog post 'AI Didn't Kill UX Design. Bootcamps Did.'

### DIFF
--- a/source/_posts/ai-didnt-kill-ux-design-bootcamps-did.md
+++ b/source/_posts/ai-didnt-kill-ux-design-bootcamps-did.md
@@ -1,0 +1,92 @@
+---
+title: AI Didn't Kill UX Design. Bootcamps Did.
+excerpt: When your entire skillset can be replicated by a well-crafted prompt, you weren't designing—you were performing design theater
+layout: blog_post
+long: true
+draft: true
+tags:
+  - blog
+  - design
+  - ai
+  - ux
+cover_image:
+date: 2025-07-09 14:30:00
+credits:
+  - role: Author
+    name: Thomas Walichiewicz
+  - role: Year
+    name: 2025
+---
+
+Watching UX bootcamp grads panic about AI replacing them is like watching someone who only knows paint-by-numbers worry about photography. Of course you're replaceable—you were never actually designing in the first place.
+
+## You Either Live as a Designer or You Don't
+
+Rick Rubin nailed it: "The world is only changed by people who are living as artists. Everyone else is just following instructions."
+
+Real designers can't turn it off. They see that Slack's view buttons are in the wrong place while trying to relax. They notice Apple Music's ambiguous heart icon creates unnecessary anxiety. They wake up at 3 AM thinking about why that microwave timer makes everyone do math.
+
+Bootcamp grads? They see a checklist. Double Diamond. Design Sprint. Journey Map. They execute processes perfectly without ever asking if they should. They know how to imitate what good designers do, but it's all performance—no understanding, no instinct, no soul.
+
+## The $15K Assembly Line
+
+Every bootcamp portfolio looks exactly the fucking same:
+
+- Stock photo personas named "Tech-Savvy Sarah"
+- Journey maps that could describe any product
+- Empathy maps saying "user wants intuitive experience"
+- The same three case studies: redesign an app, create a new feature, improve accessibility
+
+These aren't designers. They're template operators. Give them a framework and they'll execute flawlessly. Ask them to solve something without a predefined process and watch them short-circuit.
+
+## How Mediocrity Became the Hiring Manager
+
+Here's what nobody talks about: those bootcamp grads from 2016-2020? They're now Design Managers. Directors of UX. Heads of Design.
+
+And guess who they hire? More bootcamp grads.
+
+They don't recognize good design because they've never done it. Show them unconventional solutions and they ask "but where's your research documentation?" Present genuine creativity and they wonder "did you follow the design thinking process?"
+
+I've watched talented designers with decades of experience get rejected because they solve problems instead of following processes. Because they have taste instead of templates. Because they design from understanding instead of sticky notes.
+
+## Why AI Terrifies Them
+
+ChatGPT can generate personas. Claude can map user journeys. Midjourney makes mockups. When your entire skillset can be replicated by a well-crafted prompt, you weren't designing—you were performing design theater.
+
+These bootcamp grads are panicking because AI exposed the truth: they've been doing robot work all along. Following instructions. Filling templates. Creating artifacts nobody reads.
+
+Real design happens in the gap between what exists and what should exist. It's seeing problems that don't have frameworks yet. It's making creative leaps that no process can teach. It's having taste—that ineffable quality that knows why something feels wrong even when all the metrics say it's right.
+
+## The Great Filter
+
+AI isn't killing design. It's revealing who was never designing in the first place.
+
+All those "UX Researchers" who just moderate usability tests? Gone. Those "Product Designers" who only push rectangles in Figma? Replaced. The entire cottage industry of people creating deliverables instead of solving problems? Automated.
+
+Good. Let them go.
+
+## What Survives the Flood
+
+When the bootcamp bubble finally bursts, we'll have room for actual designers again. People who:
+
+- See systems, not screens
+- Solve problems that don't have templates yet
+- Understand that empathy isn't a map you fill out—it's giving a shit
+- Can't help but notice when something's wrong
+- Create from first principles, not from process
+
+The market correction is coming. Every company that hired armies of process-followers is about to realize they can get the same output from AI for 1/100th the cost. The bootcamp-trained managers who built these teams will scramble to justify their existence.
+
+They can't. Because they were never designers. They were very expensive template fillers. And templates are exactly what AI does best.
+
+## The Hard Truth
+
+If you're worried AI will replace you, it probably should. You've been cosplaying as a designer, running through ceremonies you don't understand, creating artifacts nobody needs.
+
+Either start living as a designer—observing, questioning, creating from first principles—or admit you're just in it for the tech salary. At least that's honest.
+
+The flood of bootcamp grads didn't just dilute the market. They created a self-replicating system that pushes out real design talent. They turned a craft into a checklist. They made design boring.
+
+But here's the thing: real design is unkillable. It lives in people who can't help but see the world through design eyes. Who get angry at bad door handles and obsess over invisible problems.
+
+Those people will be fine. Everyone else? Start updating your LinkedIn.


### PR DESCRIPTION
## Summary
- Adds new long-form blog post examining the impact of bootcamps on UX design
- Currently in draft status for review before publishing
- Provocative take on how AI reveals who was never really designing

## Content Overview
This post argues that:
- Bootcamps created template-based "designers" who follow processes without understanding
- These bootcamp grads are now hiring managers, perpetuating the problem
- AI threatens them because it can replicate template-based work
- Real design (first-principles thinking, taste, problem-solving) remains irreplaceable

## Test plan
- [x] Post created with proper metadata structure
- [x] Draft status ensures it won't publish immediately
- [ ] Review content for tone and messaging
- [ ] Add cover image if desired
- [ ] Change draft status to false when ready to publish

🤖 Generated with [Claude Code](https://claude.ai/code)