### PR TITLE
fix: exclude docs directory from Hexo rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,7 @@ tag_dir: blog/tags
 category_dir: blog/categories
 skip_render: 
   - "themes/san-diego/source/demos/**"
+  - "docs/**"
 
 # Writing
 default_layout: post


### PR DESCRIPTION
## Summary
- Fixes YAML parsing errors when running Hexo build
- Adds `docs/**` to `skip_render` in `_config.yml`
- Prevents Hexo from trying to process documentation files as blog posts

## Problem
Hexo was attempting to parse markdown files in the `docs/` directory as blog posts, causing YAML parsing errors:
```
YAMLException: end of the stream or a document separator is expected
```

## Solution
Documentation files don't need front matter and shouldn't be rendered as blog content. Adding them to `skip_render` tells Hexo to ignore them completely.

## Test plan
- [x] Add `docs/**` to skip_render configuration
- [ ] Verify Hexo builds without errors
- [ ] Confirm docs files are not processed as posts

🤖 Generated with [Claude Code](https://claude.ai/code)