### PR TITLE
fix: exclude scripts directory from Hexo rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ category_dir: blog/categories
 skip_render: 
   - "themes/san-diego/source/demos/**"
   - "docs/**"
+  - "scripts/**"
 
 # Writing
 default_layout: post


### PR DESCRIPTION
## Summary
- Fixes SyntaxError when running Hexo commands
- Adds `scripts/**` to `skip_render` in `_config.yml`  
- Prevents bash scripts from being loaded as JavaScript

## Problem
Hexo was attempting to load bash scripts as JavaScript modules, causing syntax errors:
```
SyntaxError: Invalid or unexpected token
    at /Users/waliwalu/GitHub/blog/scripts/ensure-safe-branch.sh:1
```

## Solution
Scripts directory contains bash files for git safety, not Hexo plugins. Adding them to `skip_render` prevents Hexo from trying to execute them.

## Test plan
- [x] Add `scripts/**` to skip_render configuration
- [ ] Verify `hexo clean && hexo generate && hexo server --draft` runs without errors
- [ ] Confirm scripts are not processed by Hexo

🤖 Generated with [Claude Code](https://claude.ai/code)