### PR TITLE
Fix search functionality issues with first result and anchor links

### DIFF
--- a/themes/san-diego/source/js/blog.js
+++ b/themes/san-diego/source/js/blog.js
@@ -958,12 +958,22 @@ document.addEventListener('DOMContentLoaded', function () {
 		const noResultsMessage = blogContent.querySelector('.no-results-message');
 		const postsOnlyButton = blogContent.querySelector('.posts-only-button');
 		const isPostsOnly = postsOnlyButton && postsOnlyButton.classList.contains('active');
+		const postsContent = document.querySelector('#postsContent');
 
 		let visibleCount = 0;
 		const visiblePosts = [];
 
 		// First, remove any existing highlights
 		removeAllHighlights(blogContent);
+
+		// Add/remove search active class to posts container
+		if (postsContent) {
+			if (query) {
+				postsContent.classList.add('search-active');
+			} else {
+				postsContent.classList.remove('search-active');
+			}
+		}
 
 		posts.forEach(post => {
 			const title = post.querySelector('h3')?.textContent.toLowerCase() || '';
@@ -980,6 +990,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
 			if (isMatch && (!isPostsOnly || isPostType)) {
 				post.style.display = '';
+				post.classList.add('search-result');
 				visibleCount++;
 				visiblePosts.push(post);
 				
@@ -989,6 +1000,7 @@ document.addEventListener('DOMContentLoaded', function () {
 				}
 			} else {
 				post.style.display = 'none';
+				post.classList.remove('search-result');
 			}
 		});
 

--- a/themes/san-diego/source/js/blog.js
+++ b/themes/san-diego/source/js/blog.js
@@ -827,6 +827,10 @@ document.addEventListener('DOMContentLoaded', function () {
 					if (parent.classList && parent.classList.contains('search-highlight')) {
 						return NodeFilter.FILTER_REJECT;
 					}
+					// Skip if inside an anchor link to preserve functionality
+					if (parent.tagName === 'A' || parent.closest('a')) {
+						return NodeFilter.FILTER_REJECT;
+					}
 					// Accept if contains search term
 					if (regex.test(node.textContent)) {
 						return NodeFilter.FILTER_ACCEPT;

--- a/themes/san-diego/source/js/utils/scroll-utility.js
+++ b/themes/san-diego/source/js/utils/scroll-utility.js
@@ -79,6 +79,8 @@ export const ScrollUtility = {
         const link = e.target.closest('a[href^="#"]');
         if (!link) return;
         
+        // Skip external anchor links
+        if (link.getAttribute('href') === '#') return;
         
         e.preventDefault();
         e.stopPropagation();
@@ -87,6 +89,11 @@ export const ScrollUtility = {
         const target = document.getElementById(targetId);
         
         if (!target) {
+            // Try to find target by looking for elements with matching id or name
+            const alternateTarget = document.querySelector(`[name="${targetId}"]`);
+            if (alternateTarget) {
+                this.scrollToTarget(alternateTarget);
+            }
             return;
         }
         

--- a/themes/san-diego/source/styles/_blog.scss
+++ b/themes/san-diego/source/styles/_blog.scss
@@ -1043,3 +1043,25 @@ body:has(.posts-only-button.active) {
 		}
 	}
 }
+
+// Fix for search results display
+// Ensure all search results show their full content
+#postsContent.search-active {
+	.post-list-item.search-result {
+		// Force display of all content within search results
+		* {
+			visibility: visible !important;
+			opacity: 1 !important;
+		}
+		
+		// Ensure preview cards are fully visible
+		.post-link-wrapper,
+		.post-preview-card,
+		.preview-cover-image,
+		.preview-content {
+			display: block !important;
+			visibility: visible !important;
+			opacity: 1 !important;
+		}
+	}
+}

--- a/themes/san-diego/source/styles/_blog.scss
+++ b/themes/san-diego/source/styles/_blog.scss
@@ -1048,28 +1048,102 @@ body:has(.posts-only-button.active) {
 // Ensure all search results show their full content
 #postsContent.search-active {
 	.post-list-item.search-result {
-		// Force display of all content within search results
-		* {
+		// Ensure preview cards are fully visible without affecting other elements
+		.post-preview-card {
 			visibility: visible !important;
 			opacity: 1 !important;
+			
+			.preview-cover-image,
+			.preview-content {
+				visibility: visible !important;
+				opacity: 1 !important;
+			}
+		}
+	}
+}
+
+// Threaded anchor results styling
+.threaded-anchor-results {
+	margin-left: 2rem;
+	margin-bottom: 1.5rem;
+	
+	@media (max-width: variables.$mobile-breakpoint) {
+		margin-left: 1rem;
+	}
+}
+
+.threaded-anchor-result {
+	display: flex;
+	gap: 0.75rem;
+	padding: 0.75rem 0;
+	border-left: 2px solid variables.$border-color;
+	padding-left: 1rem;
+	margin-bottom: 0.5rem;
+	
+	&:last-child {
+		margin-bottom: 0;
+	}
+	
+	.thread-indicator {
+		color: variables.$text-color-secondary;
+		font-size: var(--font-size-lg);
+		line-height: 1;
+		flex-shrink: 0;
+	}
+	
+	.threaded-content {
+		flex: 1;
+		min-width: 0;
+	}
+	
+	.threaded-meta {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5rem;
+		margin-bottom: 0.25rem;
+		font-size: var(--font-size-sm);
+		
+		.threaded-title {
+			font-weight: var(--font-weight-medium);
+			color: variables.$text-color;
 		}
 		
-		// Ensure preview cards are fully visible
-		.post-link-wrapper,
-		.post-preview-card,
-		.preview-cover-image,
-		.preview-content {
-			display: block !important;
-			visibility: visible !important;
-			opacity: 1 !important;
+		.threaded-date {
+			color: variables.$text-color-secondary;
+			font-size: var(--font-size-xs);
+		}
+	}
+	
+	.threaded-context {
+		font-size: var(--font-size-sm);
+		line-height: 1.4;
+		
+		.threaded-link {
+			color: variables.$text-color-secondary;
+			text-decoration: none;
+			display: block;
+			
+			&:hover {
+				color: variables.$link-color;
+				text-decoration: underline;
+			}
+		}
+	}
+	
+	// Dark mode
+	@media (prefers-color-scheme: dark) {
+		border-left-color: variables.$border-color-dark;
+		
+		.threaded-meta .threaded-title {
+			color: variables.$text-color-dark;
 		}
 		
-		// Ensure anchor links remain clickable
-		a[href^="#"] {
-			pointer-events: auto !important;
-			cursor: pointer !important;
-			z-index: 10;
-			position: relative;
+		.threaded-context .threaded-link {
+			color: variables.$text-color-secondary-dark;
+			
+			&:hover {
+				color: variables.$link-color-dark;
+			}
 		}
 	}
 }

--- a/themes/san-diego/source/styles/_blog.scss
+++ b/themes/san-diego/source/styles/_blog.scss
@@ -1063,5 +1063,13 @@ body:has(.posts-only-button.active) {
 			visibility: visible !important;
 			opacity: 1 !important;
 		}
+		
+		// Ensure anchor links remain clickable
+		a[href^="#"] {
+			pointer-events: auto !important;
+			cursor: pointer !important;
+			z-index: 10;
+			position: relative;
+		}
 	}
 }

--- a/themes/san-diego/source/styles/_blog.scss
+++ b/themes/san-diego/source/styles/_blog.scss
@@ -1027,3 +1027,19 @@ p {
 		}
 	}
 }
+
+// Fix double margin when "Posts only" is active
+// When showing only posts with preview cards, reduce margin on the wrapper
+body:has(.posts-only-button.active) {
+	#postsContent {
+		.post-list-item {
+			// Reduce margin to account for post-link-wrapper's margin
+			margin: 2rem 0;
+			
+			// Ensure the preview card link doesn't add extra margin
+			.post-link-wrapper {
+				margin: 0;
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes two critical issues with the blog search functionality:
1. First search result not showing full content (missing preview cards)
2. Anchor links not working when search highlighting is active

## Changes Made

### Fix for first search result display
- Added `search-active` class to `#postsContent` container during search
- Added `search-result` class to visible posts
- Added CSS rules to force visibility of all content within search results
- Ensures preview cards are always visible regardless of DOM position

### Fix for anchor link functionality
- Modified `highlightSearchTerms` to skip text inside anchor links
- Updated `ScrollUtility` to handle edge cases (empty anchors, name attributes)
- Added CSS to ensure anchor links remain clickable with proper z-index
- Preserves link functionality even when search highlights are active

## Test Plan
1. **First search result fix:**
   - Go to the blog page
   - Search for any term that returns multiple posts
   - Verify the first result shows its full preview card
   - Compare with behavior before fix where first result was missing content

2. **Anchor link fix:**
   - Search for a term that highlights text containing anchor links
   - Click on anchor links within search results
   - Verify they scroll to the correct destination
   - Test the "AutoMix" post mentioned in the issue

## Technical Details
- No breaking changes
- Backward compatible
- Minimal performance impact
- Follows existing code patterns

Fixes the issues discovered during search testing where certain posts would render differently based on their position in search results.

🤖 Generated with [Claude Code](https://claude.ai/code)