### PR TITLE
Fix: Display preview images for projects without demo components

### DIFF
--- a/themes/san-diego/layout/project.ejs
+++ b/themes/san-diego/layout/project.ejs
@@ -50,6 +50,13 @@
 				</div>
 			</div>
 		</div>
+		<% } else if (page.cover_image) { %>
+		<!-- Project Preview Image Section -->
+		<div class="project-preview-hero">
+			<div class="preview-image-container">
+				<img src="<%= url_for(page.path.replace('index.html', '') + page.cover_image.replace('./', '')) %>" alt="<%= page.title %> preview" class="project-preview-image" />
+			</div>
+		</div>
 		<% } %>
 		
 		<div class="project-content">
@@ -223,6 +230,27 @@
             margin-bottom: 2rem;
             border-radius: 8px;
             overflow: hidden;
+        }
+        
+        /* Preview image styles */
+        .project-preview-hero {
+            width: 100%;
+            background: var(--card-background-color, #fff);
+            margin-bottom: 2rem;
+            border-radius: 8px;
+            overflow: hidden;
+        }
+        
+        .preview-image-container {
+            width: 100%;
+            position: relative;
+        }
+        
+        .project-preview-image {
+            width: 100%;
+            height: auto;
+            display: block;
+            border-radius: 8px;
         }
         
         .trailer-content {


### PR DESCRIPTION
## Summary
- Fixed issue where projects with `cover_image` but no `demo_component` weren't displaying preview images at the top of the page
- Added proper URL path resolution for cover images in project templates
- Implemented responsive CSS styling that matches the existing demo container design

## Problem
Projects like "Human Interest 401(k) Administration" and "Overlay" were showing empty space at the top instead of their configured cover images. The template only handled preview images for projects with interactive demos.

## Solution
- Added `else if (page.cover_image)` condition to display static preview images
- Implemented `project-preview-hero` section with proper styling
- Fixed URL path construction using `page.path.replace('index.html', '') + page.cover_image.replace('./', '')`

## Test plan
- [x] Tested locally on Human Interest 401(k) project page
- [x] Verified preview image displays correctly at top of page
- [x] Confirmed responsive design matches demo container styling
- [x] Validated image URLs resolve correctly

🤖 Generated with [Claude Code](https://claude.ai/code)