### PR TITLE
fix: change project byline color to white for better visibility

### DIFF
--- a/themes/san-diego/source/styles/_project.scss
+++ b/themes/san-diego/source/styles/_project.scss
@@ -1692,11 +1692,11 @@ blockquote.pullquote {
 			font-size: var(--font-size-md);
 			text-align: right;
 			max-width: 450px;
-			color: variables.$grey-light; // Use light grey color
+			color: white;
 			text-shadow: none; // Remove text shadow in blog context
 			
 			@media (prefers-color-scheme: dark) {
-				color: variables.$grey-dark;
+				color: white;
 			}
 		}
 		


### PR DESCRIPTION
## Summary
- Changed project byline color from grey to white in blog context
- Applied to both light and dark modes for consistency
- Improves readability and visibility of the byline text

## Changes
- Modified `.blog-content .project-edge-wrapper .project-info-wrapper .project-byline` color from `variables.$grey-light` / `variables.$grey-dark` to `white`

🤖 Generated with [Claude Code](https://claude.ai/code)