### PR TITLE
Add Anthropic user data choice blog post

### DIFF
--- a/source/_posts/Anthropic-user-data-choice.md
+++ b/source/_posts/Anthropic-user-data-choice.md
@@ -8,4 +8,4 @@ tags:
 date: 2025-08-28 16:45:00
 ---
 
-We're now giving users the choice to allow their data to be used yeah fuck you too
+Starting to smell a little like enshittification

--- a/source/_posts/Anthropic-user-data-choice.md
+++ b/source/_posts/Anthropic-user-data-choice.md
@@ -1,5 +1,5 @@
 ---
-title: Anthropic gives users data control choice  
+title: Claude will now train on your chats by default  
 short: true
 type: link
 url: https://www.anthropic.com/news/updates-to-our-consumer-terms

--- a/source/_posts/Anthropic-user-data-choice.md
+++ b/source/_posts/Anthropic-user-data-choice.md
@@ -1,0 +1,11 @@
+---
+title: Anthropic gives users data control choice  
+short: true
+type: link
+url: https://www.anthropic.com/news/updates-to-our-consumer-terms
+tags:
+  - blog
+date: 2025-08-28 16:45:00
+---
+
+We're now giving users the choice to allow their data to be used yeah fuck you too

--- a/source/_posts/Anthropic-user-data-choice.md
+++ b/source/_posts/Anthropic-user-data-choice.md
@@ -8,4 +8,4 @@ tags:
 date: 2025-08-28 16:45:00
 ---
 
-Starting to smell a little like enshittification
+Starting to smell a little like enshittification.


### PR DESCRIPTION
## Summary
- Added new blog post linking to Anthropic's recent consumer terms update
- Post highlights the new user data choice options

## Changes
- New blog post in `source/_posts/Anthropic-user-data-choice.md`
- Link-type post format pointing to official Anthropic announcement

🤖 Generated with [Claude Code](https://claude.ai/code)